### PR TITLE
Add network flag for multiplayer compatibility

### DIFF
--- a/QuickRestart.cs
+++ b/QuickRestart.cs
@@ -13,7 +13,7 @@ using RoR2.UI;
 
 namespace Booth
 {
-
+    [NetworkCompatibility(CompatibilityLevel.NoNeedForSync)]
     [BepInDependency("com.bepis.r2api")]
     [BepInPlugin("com.IkalaGaming.QuickRestart", "QuickRestart", "1.3.0")]
     [R2APISubmoduleDependency(nameof(ResourcesAPI))]


### PR DESCRIPTION
Since the button is removed in multiplayer, we may as well mark it as unneeded for network sync so that users can connect to other people who don't have this mod installed.